### PR TITLE
100/responsividade breakpoints navbar

### DIFF
--- a/src/components/navbar/styled.js
+++ b/src/components/navbar/styled.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 
 const NavBarComponent = styled.nav.attrs((props) => ({
-  className: props.className || ''
+  className: props.className || '',
 }))`
   top: 0;
   position: fixed;
@@ -41,7 +41,7 @@ const NavBarComponent = styled.nav.attrs((props) => ({
       color: #f5bc4a;
     }
   }
-  a.active{
+  a.active {
     color: #f5bc4a;
     font-weight: bold;
   }
@@ -56,7 +56,7 @@ const NavBarComponent = styled.nav.attrs((props) => ({
     font-size: 30px;
     cursor: pointer;
   }
- 
+
   .aparece {
     display: flex !important;
     flex-direction: column;
@@ -101,7 +101,7 @@ const NavBarComponent = styled.nav.attrs((props) => ({
   }
 
   /* Desktop , PCs*/
-  @media (min-width: 600px) {
+  @media (min-width: 801px) {
     display: flex;
     align-items: center;
     flex-wrap: wrap;
@@ -119,7 +119,6 @@ const NavBarComponent = styled.nav.attrs((props) => ({
     }
 
     .redirecionamento {
-      gap: 40px;
       flex-wrap: wrap;
       align-items: center;
       a {
@@ -137,6 +136,11 @@ const NavBarComponent = styled.nav.attrs((props) => ({
     img {
       height: 80px;
       left: 121px;
+    }
+    @media (min-width: 801px) {
+      .redirecionamento {
+        gap: 40px;
+      }
     }
   }
 `

--- a/src/components/navbar/styled.js
+++ b/src/components/navbar/styled.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 
 const NavBarComponent = styled.nav.attrs((props) => ({
-  className: props.className || '',
+  className: props.className || ''
 }))`
   top: 0;
   position: fixed;

--- a/src/components/navbar/styled.js
+++ b/src/components/navbar/styled.js
@@ -137,7 +137,7 @@ const NavBarComponent = styled.nav.attrs((props) => ({
       height: 80px;
       left: 121px;
     }
-    @media (min-width: 801px) {
+    @media (min-width: 1023px) {
       .redirecionamento {
         gap: 40px;
       }


### PR DESCRIPTION
#100 -  Responsividade-Breakpoints-Navbar
====
  
### 🆙 CHANGELOG

-  Aplicado responsividade na barra de navegação: até 1023px a visualização é em menu hambúrguer, a partir de 1023px os itens de menu se tornam visíveis.

- Segue as medias queries utilizadas:  @media(min-width: 801px)
 @media (min-width: 1023px)

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar

- [ ] Acesse a branch 100/Responsividade-Breakpoints-Navbar;
- [ ] Inicie a aplicação;
- [ ] Teste a barra de navegação, nos diferentes tamanhos de tela;
- [ ] Teste a largura de tela, maior que 1023px e menor que 1023px;
- [ ] Ver o comportamento da Navbar, dependendo da largura da tela.
