### PR TITLE
107/fix limitar descricao carrossel

### DIFF
--- a/src/components/parceires/styled.js
+++ b/src/components/parceires/styled.js
@@ -1,10 +1,6 @@
 import styled from 'styled-components'
 
 const ParceireComponents = styled.section`
-
-
-
-    
   h2 {
     color: black;
     display: flex;
@@ -26,6 +22,11 @@ const ParceireComponents = styled.section`
     display: flex;
     flex-direction: column;
     align-items: center;
+  }
+
+  .swiper-button-next,
+  .swiper-button-prev {
+    color: white;
   }
 
   .perfil {
@@ -112,27 +113,18 @@ const ParceireComponents = styled.section`
       }
     }
   }
-  @media (max-width: 1440px){
-    .description-parceires{
+  @media (max-width: 1440px) {
+    .description-parceires {
       padding-left: 10px;
     }
   }
 
   @media (max-width: 767px) {
-
-    .swiper-button-next, .swiper-button-prev  {
+    .swiper-button-next,
+    .swiper-button-prev {
       display: block !important;
       color: white;
     }
-    /* .swiper-button-next {
-      right: 20px;
-      transform: rotate(90deg);
-    }
-
-    .swiper-button-prev {
-      left: 20px;
-      transform: rotate(90deg);
-    } */
   }
 `
 export default ParceireComponents

--- a/src/components/parceires/styled.js
+++ b/src/components/parceires/styled.js
@@ -1,6 +1,10 @@
 import styled from 'styled-components'
 
 const ParceireComponents = styled.section`
+
+
+
+    
   h2 {
     color: black;
     display: flex;
@@ -114,8 +118,13 @@ const ParceireComponents = styled.section`
     }
   }
 
-  @media (max-width: 760px) {
-    .swiper-button-next {
+  @media (max-width: 767px) {
+
+    .swiper-button-next, .swiper-button-prev  {
+      display: block !important;
+      color: white;
+    }
+    /* .swiper-button-next {
       right: 20px;
       transform: rotate(90deg);
     }
@@ -123,7 +132,7 @@ const ParceireComponents = styled.section`
     .swiper-button-prev {
       left: 20px;
       transform: rotate(90deg);
-    }
+    } */
   }
 `
 export default ParceireComponents

--- a/src/pages/home/styled.js
+++ b/src/pages/home/styled.js
@@ -70,7 +70,7 @@ const Home = styled.div`
         max-height: 100%;
         text-overflow: ellipsis;
         display: -webkit-box !important;
-        -webkit-line-clamp: 15;
+        -webkit-line-clamp: 8;
         -webkit-box-orient: vertical;
       }
 

--- a/src/pages/home/styled.js
+++ b/src/pages/home/styled.js
@@ -58,7 +58,6 @@ const Home = styled.div`
       }
 
       .descricao {
-        background-color: red;
         font-family: 'Inter', sans-serif;
         font-size: 1.3rem;
         line-height: 30px;

--- a/src/pages/home/styled.js
+++ b/src/pages/home/styled.js
@@ -58,12 +58,20 @@ const Home = styled.div`
       }
 
       .descricao {
+        background-color: red;
         font-family: 'Inter', sans-serif;
         font-size: 1.3rem;
         line-height: 30px;
         cursor: default;
         text-align: justify;
         z-index: 1;
+        overflow: hidden;
+        white-space: normal;
+        max-height: 100%;
+        text-overflow: ellipsis;
+        display: -webkit-box !important;
+        -webkit-line-clamp: 15;
+        -webkit-box-orient: vertical;
       }
 
       img {
@@ -243,6 +251,8 @@ const Home = styled.div`
   }
 
   @media ((min-width: 768px) and (max-width: 1440px)) {
+
+    
     main section .about {
       margin-bottom: 0;
     }


### PR DESCRIPTION
#107 - Limitar caracteres da descrição do carrossel principal da página Home 
====
  
### 🆙 CHANGELOG

- Adicionamos limite de linhas de texto do carrossel para 8 linhas
- Adicionamos, com CSS, reticências ao final do texto para identificar o texto foi limitado
- No carrossel de Parceires, ativamos as setas de prev e next em breakpoints abaixo de 767px
- No carrossel de Parceires, definimos as setas de prev e next na cor branca para manter o padrão do carrossel principal

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [x] Iniciar o projeto na branch #107/fix-limitar-descricao-carrossel 
- [x] No CMS, inserir um texto extenso na descrição de alguns eventos que sejam marcados como destaque
- [x] Na página home, verificar se há limitação de linhas na descrição dos eventos do carrossel, em breakpoints maiores que 767px
- [x] No carrossel de parceires, verificar se em telas mobile os botões de prev e next aparecem


