### PR TITLE
feat(parceires/styled.js): remove largura exagarada do botao parceire…

### DIFF
--- a/src/components/parceires/styled.js
+++ b/src/components/parceires/styled.js
@@ -86,9 +86,7 @@ const ParceireComponents = styled.section`
   .styled-button {
     display: flex;
     justify-content: center;
-    width: 107em;
-    padding-top: 40px;
-    padding-bottom: 60px;
+    padding: 25px 0 ;
 
       .button-parceire{
         background: #516B84;


### PR DESCRIPTION
…s - @PabloHunter - @Wander06 - @joyce-caroline - @claudionsc - @thayannregoo

#126 - conflitos-home-navbar
====
  
### 🆙 CHANGELOG

- Remoção do width do container do botão dos parceires 
- Resolução da visibilidade da página

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [ ] Abrir a branch do card: conflitos-home-navbar
- [ ] Abrir a aplicação do projeto
- [ ] Verificar se o width do botão dos parceires foi removido
- [ ] Verificar se a página home está sem problemas de visibilidade do conteúdo
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada
